### PR TITLE
Fix incorrect PROPFIND response format

### DIFF
--- a/src/dav/methods/propfind.ts
+++ b/src/dav/methods/propfind.ts
@@ -22,7 +22,7 @@ function buildResponse(
    builder.elem('D:href', property.href)
    const propStat = builder.elem('D:propstat')
    propStat.elem('D:status', `HTTP/1.1 ${status} ${StatusCode[status]}`)
-   const prop = builder.elem('D:prop')
+   const prop = propStat.elem('D:prop')
    prop.elem('D:getetag', property.id)
    prop.elem('D:getlastmodified', date2RFC1123(property.lastModified))
    prop.elem('D:creationdate', date2RFC3339(property.creationDate))


### PR DESCRIPTION
I wasn't able to browse in folders on my WebDAV client (Infuse 7.3.3). It seems like `propfind.ts` was returning invalid responses according to http://webdav.org/specs/rfc2518.html#rfc.section.8.1.1.

Before & After:
<p float="left">
<img width="300" alt="Before" src="https://user-images.githubusercontent.com/6280802/152274464-f3efa8e9-d29d-40db-99b8-b295852103a0.png">
<img width="300" alt="After" src="https://user-images.githubusercontent.com/6280802/152274473-cdf3e3d5-1aef-4a06-9424-2ac4f199d1d0.png">
</p>

